### PR TITLE
updated logstash.configuration.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ Automatically detects files that match:
 
 ## Release Notes
 
+* `0.0.3` Fixed [Language comment functionality uses incorrect syntax](https://github.com/randomchance/vscode-logstash-configuration-syntax/issues/1), comment shortcuts should work now. 

--- a/logstash.configuration.json
+++ b/logstash.configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "#"
     },
     // symbols used as brackets
     "brackets": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "logstash",
     "displayName": "Logstash Configuration Syntax / Language Support",
     "description": "Adds syntax highlighting for logstash configuration files.",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "publisher": "RandomChance",
     "license": "SEE LICENSE IN LICENSE.md",
     "icon": "images/icon-logstash.svg",


### PR DESCRIPTION
Closes #1 

- Removes the block comment syntax and sets the line syntax to "#".
- Bumped version.
- Updated release notes.