### PR TITLE
Single quoted strings and escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ Automatically detects files that match:
 
 ## Release Notes
 
+* `0.0.4` Fixed strings with quotes.
 * `0.0.3` Fixed [Language comment functionality uses incorrect syntax](https://github.com/randomchance/vscode-logstash-configuration-syntax/issues/1), comment shortcuts should work now. 

--- a/examples/example.logstash.conf
+++ b/examples/example.logstash.conf
@@ -7,6 +7,9 @@ filter {
   date {
     match => [ "timestamp" , "dd/MMM/yyyy:HH:mm:ss Z" ]
   }
+  if ([somefield] =~ "{\"prop\"" or [somefield] =~ '{\'prop\'') {
+     # Do something special
+  }
 }
 
 output {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "logstash",
     "displayName": "Logstash Configuration Syntax / Language Support",
     "description": "Adds syntax highlighting for logstash configuration files.",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "publisher": "RandomChance",
     "license": "SEE LICENSE IN LICENSE.md",
     "icon": "images/icon-logstash.svg",

--- a/syntaxes/logstash.tmLanguage
+++ b/syntaxes/logstash.tmLanguage
@@ -67,9 +67,43 @@
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>String values</string>
-			<key>match</key>
-			<string>(")(.+?)[^"]*(")</string>
+			<string>Double quoted string values</string>
+			<key>begin</key>
+			<string>"</string>
+			<key>end</key>
+			<string>"</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\"</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>[^"]</string>
+				</dict>
+			</array>
+			<key>name</key>
+			<string>string.text.logstash</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Single quoted string values</string>
+			<key>begin</key>
+			<string>'</string>
+			<key>end</key>
+			<string>'</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\'</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>[^']</string>
+				</dict>
+			</array>
 			<key>name</key>
 			<string>string.text.logstash</string>
 		</dict>


### PR DESCRIPTION
Changed string literal language definition to include single quoted strings and escaping as per the Logstash documentation.

Extended example to show the string syntax.

Bumped version.

Updated release notes.